### PR TITLE
Update colors grid to 3 columns on large screens

### DIFF
--- a/functions/theme-options-admin.php
+++ b/functions/theme-options-admin.php
@@ -87,15 +87,41 @@ function sigil_theme_options_page() {
                     </div>
                     
                     <div class="sigil-color-section">
+                        <h3><?php _e('Secondary Colors', 'sigil'); ?></h3>
+                        <?php sigil_render_color_options('secondary'); ?>
+                    </div>
+                    
+                    <div class="sigil-color-section">
+                        <h3><?php _e('Accent Colors', 'sigil'); ?></h3>
+                        <?php sigil_render_color_options('accent'); ?>
+                    </div>
+                    
+                    <div class="sigil-color-section">
                         <h3><?php _e('Background Colors', 'sigil'); ?></h3>
+                        <p><?php _e('Set the main page/body background colors for both light and dark modes.', 'sigil'); ?></p>
                         <?php sigil_render_color_options('light_bg'); ?>
                         <?php sigil_render_color_options('dark_bg'); ?>
                     </div>
                     
                     <div class="sigil-color-section">
                         <h3><?php _e('Text Colors', 'sigil'); ?></h3>
+                        <p><?php _e('Set the main text colors for headings, paragraphs, and other typography elements.', 'sigil'); ?></p>
                         <?php sigil_render_color_options('light_text'); ?>
                         <?php sigil_render_color_options('dark_text'); ?>
+                    </div>
+                    
+                    <div class="sigil-color-section">
+                        <h3><?php _e('Foreground Colors', 'sigil'); ?></h3>
+                        <p><?php _e('Colors for cards, content areas, and blockquotes (separate from main text colors).', 'sigil'); ?></p>
+                        <?php sigil_render_color_options('light_fg'); ?>
+                        <?php sigil_render_color_options('dark_fg'); ?>
+                    </div>
+                    
+                    <div class="sigil-color-section">
+                        <h3><?php _e('Foreground Text Colors', 'sigil'); ?></h3>
+                        <p><?php _e('Text colors for cards, content areas, and other foreground elements.', 'sigil'); ?></p>
+                        <?php sigil_render_color_options('light_fg_text'); ?>
+                        <?php sigil_render_color_options('dark_fg_text'); ?>
                     </div>
                 </div>
             </div>
@@ -586,6 +612,63 @@ function sigil_footer_page() {
     }
     </style>
     <?php
+}
+
+/**
+ * Get color name choices for dropdowns
+ */
+function sigil_get_color_name_choices() {
+    return [
+        'white' => __('White', 'sigil'),
+        'black' => __('Black', 'sigil'),
+        'red' => __('Red', 'sigil'),
+        'pink' => __('Pink', 'sigil'),
+        'fuchsia' => __('Fuchsia', 'sigil'),
+        'purple' => __('Purple', 'sigil'),
+        'violet' => __('Violet', 'sigil'),
+        'indigo' => __('Indigo', 'sigil'),
+        'blue' => __('Blue', 'sigil'),
+        'azure' => __('Azure', 'sigil'),
+        'cyan' => __('Cyan', 'sigil'),
+        'jade' => __('Jade', 'sigil'),
+        'green' => __('Green', 'sigil'),
+        'lime' => __('Lime', 'sigil'),
+        'yellow' => __('Yellow', 'sigil'),
+        'amber' => __('Amber', 'sigil'),
+        'pumpkin' => __('Pumpkin', 'sigil'),
+        'orange' => __('Orange', 'sigil'),
+        'sand' => __('Sand', 'sigil'),
+        'grey' => __('Grey', 'sigil'),
+        'zinc' => __('Zinc', 'sigil'),
+        'slate' => __('Slate', 'sigil'),
+    ];
+}
+
+/**
+ * Get color shade choices for dropdowns
+ */
+function sigil_get_color_shade_choices() {
+    return [
+        '50' => __('50 (Lightest)', 'sigil'),
+        '100' => __('100', 'sigil'),
+        '150' => __('150', 'sigil'),
+        '200' => __('200', 'sigil'),
+        '250' => __('250', 'sigil'),
+        '300' => __('300', 'sigil'),
+        '350' => __('350', 'sigil'),
+        '400' => __('400', 'sigil'),
+        '450' => __('450 (Default)', 'sigil'),
+        '500' => __('500', 'sigil'),
+        '550' => __('550', 'sigil'),
+        '600' => __('600', 'sigil'),
+        '650' => __('650', 'sigil'),
+        '700' => __('700', 'sigil'),
+        '750' => __('750', 'sigil'),
+        '800' => __('800', 'sigil'),
+        '850' => __('850', 'sigil'),
+        '900' => __('900', 'sigil'),
+        '950' => __('950 (Darkest)', 'sigil'),
+    ];
 }
 
 /**

--- a/functions/theme-options-admin.php
+++ b/functions/theme-options-admin.php
@@ -285,6 +285,13 @@ function sigil_theme_options_page() {
         gap: 20px;
     }
     
+    /* 3-column grid for larger screens */
+    @media (min-width: 1024px) {
+        .sigil-colors-grid {
+            grid-template-columns: repeat(3, 1fr);
+        }
+    }
+    
     .sigil-color-section {
         background: #fff;
         border: 1px solid #ccd0d4;

--- a/functions/theme-options-old.php
+++ b/functions/theme-options-old.php
@@ -678,63 +678,6 @@ function sigil_sanitize_color_shade($input) {
 }
 
 /**
- * Get color name choices for dropdowns
- */
-function sigil_get_color_name_choices() {
-    return [
-        'white' => __('White', 'sigil'),
-        'black' => __('Black', 'sigil'),
-        'red' => __('Red', 'sigil'),
-        'pink' => __('Pink', 'sigil'),
-        'fuchsia' => __('Fuchsia', 'sigil'),
-        'purple' => __('Purple', 'sigil'),
-        'violet' => __('Violet', 'sigil'),
-        'indigo' => __('Indigo', 'sigil'),
-        'blue' => __('Blue', 'sigil'),
-        'azure' => __('Azure', 'sigil'),
-        'cyan' => __('Cyan', 'sigil'),
-        'jade' => __('Jade', 'sigil'),
-        'green' => __('Green', 'sigil'),
-        'lime' => __('Lime', 'sigil'),
-        'yellow' => __('Yellow', 'sigil'),
-        'amber' => __('Amber', 'sigil'),
-        'pumpkin' => __('Pumpkin', 'sigil'),
-        'orange' => __('Orange', 'sigil'),
-        'sand' => __('Sand', 'sigil'),
-        'grey' => __('Grey', 'sigil'),
-        'zinc' => __('Zinc', 'sigil'),
-        'slate' => __('Slate', 'sigil'),
-    ];
-}
-
-/**
- * Get color shade choices for dropdowns
- */
-function sigil_get_color_shade_choices() {
-    return [
-        '50' => __('50 (Lightest)', 'sigil'),
-        '100' => __('100', 'sigil'),
-        '150' => __('150', 'sigil'),
-        '200' => __('200', 'sigil'),
-        '250' => __('250', 'sigil'),
-        '300' => __('300', 'sigil'),
-        '350' => __('350', 'sigil'),
-        '400' => __('400', 'sigil'),
-        '450' => __('450 (Default)', 'sigil'),
-        '500' => __('500', 'sigil'),
-        '550' => __('550', 'sigil'),
-        '600' => __('600', 'sigil'),
-        '650' => __('650', 'sigil'),
-        '700' => __('700', 'sigil'),
-        '750' => __('750', 'sigil'),
-        '800' => __('800', 'sigil'),
-        '850' => __('850', 'sigil'),
-        '900' => __('900', 'sigil'),
-        '950' => __('950 (Darkest)', 'sigil'),
-    ];
-}
-
-/**
  * Get resolved color value based on mode (preset or custom)
  */
 function sigil_get_resolved_color($color_type) {


### PR DESCRIPTION
- Add media query for screens 1024px and larger
- Colors grid now displays 3 columns instead of auto-fit
- Maintains responsive design for smaller screens
- Better organization of color sections on desktop